### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ php:
   - 7.3
   - master
 
+matrix:
+  allow_failures:
+    - php: master
+
 sudo: false
 
 install: travis_retry composer install

--- a/tests/Integration/SimpleFileFetcherTest.php
+++ b/tests/Integration/SimpleFileFetcherTest.php
@@ -31,27 +31,27 @@ class SimpleFileFetcherTest extends TestCase {
 			'https://raw.githubusercontent.com/JeroenDeDauw/FileFetcher/master/tests/Integration/SimpleFileFetcherTest.php'
 		);
 
-		$this->assertInternalType( 'string', $contents );
+		$this->assertIsString( $contents );
 
-		$this->assertInternalType( 'integer', strpos( $contents, __FUNCTION__ ) );
+		$this->assertContains( __FUNCTION__, $contents );
 	}
 
 	public function testGivenNotFoundFile_exceptionIsThrown() {
 		$fetcher = new SimpleFileFetcher();
+		$invalidRemoteFileUrl = 'http://raw.github.com/JeroenDeDauw/FileFetcher/master/foo.php';
 
 		$this->expectException( FileFetchingException::class );
-		$fetcher->fetchFile(
-			'http://raw.github.com/JeroenDeDauw/FileFetcher/master/foo.php'
-		);
+		$this->expectExceptionMessage( 'Could not fetch file: ' . $invalidRemoteFileUrl );
+		$fetcher->fetchFile( $invalidRemoteFileUrl );
 	}
 
 	public function testGivenInvalidUrl_exceptionIsThrown() {
 		$fetcher = new SimpleFileFetcher();
+		$invalidRemoteFileUrl = 'foo bar baz';
 
 		$this->expectException( FileFetchingException::class );
-		$fetcher->fetchFile(
-			'foo bar baz'
-		);
+		$this->expectExceptionMessage( 'Could not fetch file: ' . $invalidRemoteFileUrl );
+		$fetcher->fetchFile( $invalidRemoteFileUrl );
 	}
 
 }

--- a/tests/Unit/CallbackFileFetcherTest.php
+++ b/tests/Unit/CallbackFileFetcherTest.php
@@ -28,8 +28,10 @@ class CallbackFileFetcherTest extends TestCase {
 		$fetcher = new CallbackFileFetcher( function( string $fileUrl ) {
 			throw new FileFetchingException( $fileUrl );
 		} );
+		$invalidFileUrl = 'Such';
 
 		$this->expectException( FileFetchingException::class );
+		$this->expectExceptionMessage( 'Could not fetch file: ' . $invalidFileUrl );
 		$fetcher->fetchFile( 'Such' );
 	}
 

--- a/tests/Unit/ErrorLoggingFileFetcherTest.php
+++ b/tests/Unit/ErrorLoggingFileFetcherTest.php
@@ -35,8 +35,10 @@ class ErrorLoggingFileFetcherTest extends TestCase {
 			new ThrowingFileFetcher(),
 			new NullLogger()
 		);
+		$invalidFilePath = 'song.txt';
 		$this->expectException( FileFetchingException::class );
-		$errorLoggingFileFetcher->fetchFile( 'song.txt' );
+		$this->expectExceptionMessage( 'Could not fetch file: ' . $invalidFilePath );
+		$errorLoggingFileFetcher->fetchFile( $invalidFilePath );
 	}
 
 	public function testWhenWrappedFetcherThrowsAnException_theExceptionIsLogged() {

--- a/tests/Unit/InMemoryFileFetcherTest.php
+++ b/tests/Unit/InMemoryFileFetcherTest.php
@@ -4,9 +4,11 @@ declare( strict_types = 1 );
 
 namespace FileFetcher\Tests\Unit;
 
+use InvalidArgumentException;
 use FileFetcher\FileFetchingException;
 use FileFetcher\InMemoryFileFetcher;
 use PHPUnit\Framework\TestCase;
+use Nette\InvalidArgumentException as NetteInvalidArgumentException;
 
 /**
  * @covers \FileFetcher\InMemoryFileFetcher
@@ -18,18 +20,22 @@ class InMemoryFileFetcherTest extends TestCase {
 
 	public function testWhenEmptyHash_requestsCauseException() {
 		$fetcher = new InMemoryFileFetcher( [] );
+		$invalidFileUrl = 'http://foo.bar/baz';
 
 		$this->expectException( FileFetchingException::class );
-		$fetcher->fetchFile( 'http://foo.bar/baz' );
+		$this->expectExceptionMessage( 'Could not fetch file: ' . $invalidFileUrl );
+		$fetcher->fetchFile( $invalidFileUrl );
 	}
 
 	public function testWhenUrlNotKnown_requestsCauseException() {
 		$fetcher = new InMemoryFileFetcher( [
 			'http://something.else/entirely' => 'kittens'
 		] );
+		$invalidFileUrl = 'http://foo.bar/baz';
 
 		$this->expectException( FileFetchingException::class );
-		$fetcher->fetchFile( 'http://foo.bar/baz' );
+		$this->expectExceptionMessage( 'Could not fetch file: ' . $invalidFileUrl );
+		$fetcher->fetchFile( $invalidFileUrl );
 	}
 
 	public function testWhenUrlKnown_requestsReturnsValue() {
@@ -56,6 +62,18 @@ class InMemoryFileFetcherTest extends TestCase {
 		);
 
 		$this->assertSame( 'cats', $fetcher->fetchFile( 'http://foo.bar' ) );
+	}
+
+	public function testWhenFilesAreNotStringType() {
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Both file url and file contents need to be of type string' );
+
+		new InMemoryFileFetcher(
+			[
+				'http://foo.bar' => 1000,
+			],
+			'default kittens'
+		);
 	}
 
 }

--- a/tests/Unit/SpyingFileFetcherTest.php
+++ b/tests/Unit/SpyingFileFetcherTest.php
@@ -28,8 +28,11 @@ class SpyingFileFetcherTest extends TestCase {
 
 		$this->assertSame( 'content', $spyingFetcher->fetchFile( 'url' ) );
 
+		$invalidFilePath = 'foo';
+
 		$this->expectException( FileFetchingException::class );
-		$spyingFetcher->fetchFile( 'foo' );
+		$this->expectExceptionMessage( 'Could not fetch file: ' . $invalidFilePath );
+		$spyingFetcher->fetchFile( $invalidFilePath );
 	}
 
 	public function testWhenNoCalls_getFetchedUrlsReturnsEmptyArray() {
@@ -38,8 +41,10 @@ class SpyingFileFetcherTest extends TestCase {
 		] );
 
 		$spyingFetcher = new SpyingFileFetcher( $innerFetcher );
+		$result = $spyingFetcher->getFetchedUrls();
 
-		$this->assertSame( [], $spyingFetcher->getFetchedUrls() );
+		$this->assertIsArray( $result );
+		$this->assertSame( [], $result );
 	}
 
 	public function testWhenSomeCalls_getFetchedUrlsReturnsTheArguments() {


### PR DESCRIPTION
# Changed log
- Using the `assertIsString` to check the expected type is `string`.
- Using the `assertIsInt` to check the expected type is `integer`.
- Using the `assertIsArray` to check expected type is `array`.
- Using the `expectExceptionMessage` to check expected exception message is same as actual.
- Add the test for `InMemoryFileFetcher` class constructor.