### PR TITLE
Remove implicitly nullable parameters

### DIFF
--- a/src/FileFetchingException.php
+++ b/src/FileFetchingException.php
@@ -17,7 +17,7 @@ class FileFetchingException extends \RuntimeException {
 	 */
 	private $fileUrl;
 
-	public function __construct( string $fileUrl, string $message = null, \Exception $previous = null ) {
+	public function __construct( string $fileUrl, ?string $message = null, ?\Exception $previous = null ) {
 		$this->fileUrl = $fileUrl;
 
 		parent::__construct(

--- a/src/InMemoryFileFetcher.php
+++ b/src/InMemoryFileFetcher.php
@@ -29,7 +29,7 @@ class InMemoryFileFetcher implements FileFetcher {
 	 * @param string|null $defaultContent Content that is returned when there is no matching entry in $files
 	 * @throws InvalidArgumentException
 	 */
-	public function __construct( array $files, string $defaultContent = null ) {
+	public function __construct( array $files, ?string $defaultContent = null ) {
 		foreach ( $files as $url => $fileContents ) {
 			if ( !is_string( $url ) || !is_string( $fileContents ) ) {
 				throw new InvalidArgumentException( 'Both file url and file contents need to be of type string' );


### PR DESCRIPTION
They are deprecated in PHP 8.4 and create deprecation notices when using the library in a PHP 8.4 runtime.